### PR TITLE
Fix a few wrong types and add more convenience methods

### DIFF
--- a/addons/sound_manager/abstract_audio_player_pool.gd
+++ b/addons/sound_manager/abstract_audio_player_pool.gd
@@ -5,7 +5,11 @@ var busy_players: Array = []
 var bus: String = "Master"
 
 
-func _init(possible_busses: Array = [], pool_size: int = 8) -> void:
+export var default_busses := []
+export var default_pool_size := 8
+
+
+func _init(possible_busses: Array = default_busses, pool_size: int = default_pool_size) -> void:
 	for possible_bus in possible_busses:
 		if AudioServer.get_bus_index(possible_bus) > -1:
 			bus = possible_bus

--- a/addons/sound_manager/abstract_audio_player_pool.gd
+++ b/addons/sound_manager/abstract_audio_player_pool.gd
@@ -1,12 +1,13 @@
 extends Node
 
-var available_players: Array = []
-var busy_players: Array = []
-var bus: String = "Master"
-
 
 export var default_busses := []
 export var default_pool_size := 8
+
+
+var available_players: Array = []
+var busy_players: Array = []
+var bus: String = "Master"
 
 
 func _init(possible_busses: Array = default_busses, pool_size: int = default_pool_size) -> void:

--- a/addons/sound_manager/music.gd
+++ b/addons/sound_manager/music.gd
@@ -8,7 +8,7 @@ func _init():
 	._init(["Music", "music"], 2)
 
 
-func play(resource: AudioStream, crossfade_duration: int = 0, override_bus: String = "") -> AudioStreamPlayer:
+func play(resource: AudioStream, volume: float = 0.0, crossfade_duration: float = 0.0, override_bus: String = "") -> AudioStreamPlayer:
 	stop(crossfade_duration * 2)
 	
 	var player = _get_player_with_music(resource)
@@ -16,12 +16,12 @@ func play(resource: AudioStream, crossfade_duration: int = 0, override_bus: Stri
 	# If the player already exists then just make sure the volume is right (it might have just
 	# been fading in or out)
 	if player != null:
-		fade_volume(player, player.volume_db, 0, crossfade_duration)
+		fade_volume(player, player.volume_db, volume, crossfade_duration)
 		return player
 	
 	# Otherwise we need to prep another player and handle its introduction
 	player = prepare(resource, override_bus)
-	fade_volume(player, -80, 0, crossfade_duration)
+	fade_volume(player, -80.0, volume, crossfade_duration)
 
 	player.call_deferred("play")
 	return player
@@ -34,9 +34,9 @@ func is_playing(resource: AudioStream) -> bool:
 		return busy_players.size() > 0
 
 
-func stop(fade_out_duration: int = 0) -> void:
+func stop(fade_out_duration: float = 0.0) -> void:
 	for player in busy_players:
-		if fade_out_duration <= 0:
+		if fade_out_duration <= 0.0:
 			fade_out_duration = 0.01
 		fade_volume(player, player.volume_db, -80, fade_out_duration)
 
@@ -48,7 +48,7 @@ func _get_player_with_music(resource: AudioStream) -> AudioStreamPlayer:
 	return null
 
 
-func fade_volume(player: AudioStreamPlayer, from_volume: int, to_volume: int, duration: int) -> AudioStreamPlayer:
+func fade_volume(player: AudioStreamPlayer, from_volume: float, to_volume: float, duration: float) -> AudioStreamPlayer:
 	# Remove any tweens that might already be on this player
 	_remove_tween(player)
 	
@@ -85,10 +85,10 @@ func _remove_tween(player: AudioStreamPlayer) -> void:
 ### Signals
 
 
-func _on_fade_completed(player: AudioStreamPlayer, tween: Tween, from_volume: int, to_volume: int, duration: float):
+func _on_fade_completed(player: AudioStreamPlayer, tween: Tween, from_volume: float, to_volume: float, duration: float):
 	_remove_tween(player)
 	
 	# If we just faded out then our player is now available
-	if to_volume <= -79:
+	if to_volume <= -79.0:
 		player.stop()
 		mark_player_as_available(player)

--- a/addons/sound_manager/plugin.gd
+++ b/addons/sound_manager/plugin.gd
@@ -3,7 +3,7 @@ extends EditorPlugin
 
 
 func _enter_tree():
-	add_autoload_singleton("SoundManager", "res://addons/sound_manager/sound_manager.gd")
+	add_autoload_singleton("SoundManager", "res://addons/sound_manager/sound_manager.tscn")
 
 
 func _exit_tree():

--- a/addons/sound_manager/sound_effects.gd
+++ b/addons/sound_manager/sound_effects.gd
@@ -1,10 +1,6 @@
 extends "res://addons/sound_manager/abstract_audio_player_pool.gd"
 
 
-func _init(possible_busses: Array = []):
-	._init(possible_busses, 8)
-
-
 func play(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
 	var player = prepare(resource, override_bus)
 	player.call_deferred("play")

--- a/addons/sound_manager/sound_manager.gd
+++ b/addons/sound_manager/sound_manager.gd
@@ -5,44 +5,45 @@ const SoundEffectsPlayer = preload("res://addons/sound_manager/sound_effects.gd"
 const MusicPlayer = preload("res://addons/sound_manager/music.gd")
 
 
-onready var sound_effects: SoundEffectsPlayer = SoundEffectsPlayer.new(["Sounds", "sounds", "SFX"])
-onready var ui_sound_effects: SoundEffectsPlayer = SoundEffectsPlayer.new(["UI", "Interface", "interface", "Sounds", "sounds", "SFX"])
-onready var music: MusicPlayer = MusicPlayer.new()
+# moved to export vars in abstract_audio_player_pool.gd
+# default values assigned in the scene
+# onready var sound_effects: SoundEffectsPlayer = SoundEffectsPlayer.new(["Sounds", "sounds", "SFX"])
+# onready var ui_sound_effects: SoundEffectsPlayer = SoundEffectsPlayer.new(["UI", "Interface", "interface", "Sounds", "sounds", "SFX"])
+# onready var music: MusicPlayer = MusicPlayer.new()
 
 
-func _ready() -> void:
-	add_child(sound_effects)
-	add_child(ui_sound_effects)
-	add_child(music)
+onready var sound_effects: SoundEffectsPlayer = $sound_effects
+onready var ui_sound_effects: SoundEffectsPlayer = $ui_sound_effects
+onready var music: MusicPlayer = $music
 
 
 func play_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
-	return sound_effects.play(resource, override_bus)
+	return $sound_effects.play(resource, override_bus)
 
 
 func play_ui_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
-	return ui_sound_effects.play(resource, override_bus)
+	return $ui_sound_effects.play(resource, override_bus)
 
 
 func set_default_sound_bus(bus: String) -> void:
-	sound_effects.bus = bus
+	$sound_effects.bus = bus
 
 
 func set_default_ui_sound_bus(bus: String) -> void:
-	ui_sound_effects.bus = bus
+	$ui_sound_effects.bus = bus
 
 
-func play_music(resource: AudioStream, crossfade_duration: int = 0, override_bus: String = "") -> AudioStreamPlayer:
-	return music.play(resource, crossfade_duration, override_bus)
+func play_music(resource: AudioStream, volume: float = 0.0, crossfade_duration: float = 0.0, override_bus: String = "") -> AudioStreamPlayer:
+	return $music.play(resource, volume, crossfade_duration, override_bus)
 
 
 func is_music_playing(resource: AudioStream = null) -> bool:
-	return music.is_playing(resource)
+	return $music.is_playing(resource)
 
 
-func stop_music(fade_out_duration: int = 0) -> void:
-	music.stop(fade_out_duration)
+func stop_music(fade_out_duration: float = 0) -> void:
+	$music.stop(fade_out_duration)
 
 
 func set_default_music_bus(bus: String) -> void:
-	music.bus = bus
+	$music.bus = bus

--- a/addons/sound_manager/sound_manager.gd
+++ b/addons/sound_manager/sound_manager.gd
@@ -41,6 +41,14 @@ func is_music_playing(resource: AudioStream = null) -> bool:
 	return music.is_playing(resource)
 
 
+# this is not very good
+func get_current_music():
+	if music.busy_players:
+		return music.busy_players[0].stream.resource_path
+	else:
+		return null
+
+
 func stop_music(fade_out_duration: float = 0) -> void:
 	music.stop(fade_out_duration)
 

--- a/addons/sound_manager/sound_manager.gd
+++ b/addons/sound_manager/sound_manager.gd
@@ -18,32 +18,32 @@ onready var music: MusicPlayer = $music
 
 
 func play_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
-	return $sound_effects.play(resource, override_bus)
+	return sound_effects.play(resource, override_bus)
 
 
 func play_ui_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
-	return $ui_sound_effects.play(resource, override_bus)
+	return ui_sound_effects.play(resource, override_bus)
 
 
 func set_default_sound_bus(bus: String) -> void:
-	$sound_effects.bus = bus
+	sound_effects.bus = bus
 
 
 func set_default_ui_sound_bus(bus: String) -> void:
-	$ui_sound_effects.bus = bus
+	ui_sound_effects.bus = bus
 
 
 func play_music(resource: AudioStream, volume: float = 0.0, crossfade_duration: float = 0.0, override_bus: String = "") -> AudioStreamPlayer:
-	return $music.play(resource, volume, crossfade_duration, override_bus)
+	return music.play(resource, volume, crossfade_duration, override_bus)
 
 
 func is_music_playing(resource: AudioStream = null) -> bool:
-	return $music.is_playing(resource)
+	return music.is_playing(resource)
 
 
 func stop_music(fade_out_duration: float = 0) -> void:
-	$music.stop(fade_out_duration)
+	music.stop(fade_out_duration)
 
 
 func set_default_music_bus(bus: String) -> void:
-	$music.bus = bus
+	music.bus = bus

--- a/addons/sound_manager/sound_manager.gd
+++ b/addons/sound_manager/sound_manager.gd
@@ -5,16 +5,9 @@ const SoundEffectsPlayer = preload("res://addons/sound_manager/sound_effects.gd"
 const MusicPlayer = preload("res://addons/sound_manager/music.gd")
 
 
-# moved to export vars in abstract_audio_player_pool.gd
-# default values assigned in the scene
-# onready var sound_effects: SoundEffectsPlayer = SoundEffectsPlayer.new(["Sounds", "sounds", "SFX"])
-# onready var ui_sound_effects: SoundEffectsPlayer = SoundEffectsPlayer.new(["UI", "Interface", "interface", "Sounds", "sounds", "SFX"])
-# onready var music: MusicPlayer = MusicPlayer.new()
-
-
-onready var sound_effects: SoundEffectsPlayer = $sound_effects
-onready var ui_sound_effects: SoundEffectsPlayer = $ui_sound_effects
-onready var music: MusicPlayer = $music
+onready var sound_effects: SoundEffectsPlayer = $SoundEffects
+onready var ui_sound_effects: SoundEffectsPlayer = $UISoundEffects
+onready var music: MusicPlayer = $Music
 
 
 func play_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
@@ -33,20 +26,36 @@ func set_default_ui_sound_bus(bus: String) -> void:
 	ui_sound_effects.bus = bus
 
 
-func play_music(resource: AudioStream, volume: float = 0.0, crossfade_duration: float = 0.0, override_bus: String = "") -> AudioStreamPlayer:
+func play_music(resource: AudioStream, crossfade_duration: float = 0.0, override_bus: String = "") -> AudioStreamPlayer:
+	return music.play(resource, 0.0, crossfade_duration, override_bus)
+
+
+func play_music_at_volume(resource: AudioStream, volume: float = 0.0, crossfade_duration: float = 0.0, override_bus: String = "") -> AudioStreamPlayer:
 	return music.play(resource, volume, crossfade_duration, override_bus)
+
+
+func get_music_track_history() -> Array:
+	return music.track_history
+
+
+func get_last_played_music_track() -> String:
+	return music.track_history[0]
 
 
 func is_music_playing(resource: AudioStream = null) -> bool:
 	return music.is_playing(resource)
+	
+
+func is_music_track_playing(resource_path: String) -> bool:
+	return music.is_track_playing(resource_path)
 
 
-# this is not very good
-func get_current_music():
-	if music.busy_players:
-		return music.busy_players[0].stream.resource_path
-	else:
-		return null
+func get_currently_playing_music() -> Array:
+	return music.get_current()
+
+
+func get_currently_playing_music_tracks() -> Array:
+	return music.get_current_tracks()
 
 
 func stop_music(fade_out_duration: float = 0) -> void:

--- a/addons/sound_manager/sound_manager.tscn
+++ b/addons/sound_manager/sound_manager.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://addons/sound_manager/sound_manager.gd" type="Script" id=1]
+[ext_resource path="res://addons/sound_manager/sound_effects.gd" type="Script" id=2]
+[ext_resource path="res://addons/sound_manager/music.gd" type="Script" id=3]
+
+[node name="SoundManager" type="Node"]
+script = ExtResource( 1 )
+
+[node name="sound_effects" type="Node" parent="."]
+script = ExtResource( 2 )
+default_busses = [ "Sounds", "sounds", "SFX" ]
+
+[node name="ui_sound_effects" type="Node" parent="."]
+script = ExtResource( 2 )
+default_busses = [ "UI", "Interface", "interface", "Sounds", "sounds", "SFX" ]
+
+[node name="music" type="Node" parent="."]
+script = ExtResource( 3 )
+default_busses = [ "Music", "music" ]

--- a/addons/sound_manager/sound_manager.tscn
+++ b/addons/sound_manager/sound_manager.tscn
@@ -7,14 +7,15 @@
 [node name="SoundManager" type="Node"]
 script = ExtResource( 1 )
 
-[node name="sound_effects" type="Node" parent="."]
+[node name="SoundEffects" type="Node" parent="."]
 script = ExtResource( 2 )
 default_busses = [ "Sounds", "sounds", "SFX" ]
 
-[node name="ui_sound_effects" type="Node" parent="."]
+[node name="UISoundEffects" type="Node" parent="."]
 script = ExtResource( 2 )
 default_busses = [ "UI", "Interface", "interface", "Sounds", "sounds", "SFX" ]
 
-[node name="music" type="Node" parent="."]
+[node name="Music" type="Node" parent="."]
 script = ExtResource( 3 )
 default_busses = [ "Music", "music" ]
+default_pool_size = 2

--- a/docs/Music.md
+++ b/docs/Music.md
@@ -6,9 +6,35 @@
 
     This returns the `AudioStreamPlayer` that is playing the sound so you can make any other adjustments you need.
 
+- **`SoundManager.play_music_at_volume(resource: AudioStream, volume: float = 0.0, crossfade_duration: int = 0, override_bus: String = "") -> AudioStreamPlayer`**
+
+    Play some music at a given volume with an optional fade in (or crossfade if something is already playing) and optionally specify which audio bus to use.
+
+    This returns the `AudioStreamPlayer` that is playing the sound so you can make any other adjustments you need.
+
+- **`SoundManager.get_music_track_history() -> Array`**
+
+    Get the list of recently played resource paths (capped at 50).
+
+- **`SoundManager.get_last_played_music_track() -> String`**
+
+    Get the last played resource path.
+
 - **`SoundManager.is_music_playing(resource: AudioStream = null) -> bool`**
 
     Checks whether a specific audio resource is currently playing. If no resource is given it will tell you whether *anything* is currently playing.
+
+- **`SoundManager.is_music_track_playing(resource_path: String) -> bool`**
+
+    Checks whether a given audio resource path is currently playing.
+
+- **`SoundManager.get_currently_playing_music() -> Array`**
+
+    Get the list of currently playing audio streams.
+
+- **`SoundManager.get_currently_playing_music_tracks() -> Array`**
+
+    Get the list of currently playing audio stream resource paths.
 
 - **`SoundManager.stop_music(fade_out_duration: int = 0) -> void`**
 


### PR DESCRIPTION
I restructured the sound_manager object into a scene. This way, it's children already exist during the first frame of the game and are available to play music if called during _ready() of other nodes. The previous structure created the nodes during the first frame's _ready() AND added them, and the creation of a node cannot be completed in a single engine frame.

I also fixed a bunch of incorrect type annotations, just changing int -> float.

I also added a volume parameter to play_music(). It uses that value to set the tween's target.