### PR TITLE
Show a warning when sharing buses

### DIFF
--- a/addons/sound_manager/sound_manager.gd
+++ b/addons/sound_manager/sound_manager.gd
@@ -38,6 +38,7 @@ func _init() -> void:
 
 
 func set_sound_volume(volume_between_0_and_1) -> void:
+	_show_shared_bus_warning()
 	AudioServer.set_bus_volume_db(AudioServer.get_bus_index(sound_effects.bus), linear_to_db(volume_between_0_and_1))
 	AudioServer.set_bus_volume_db(AudioServer.get_bus_index(ui_sound_effects.bus), linear_to_db(volume_between_0_and_1))
 
@@ -59,6 +60,7 @@ func set_default_ui_sound_bus(bus: String) -> void:
 
 
 func set_music_volume(volume_between_0_and_1: float) -> void:
+	_show_shared_bus_warning()
 	AudioServer.set_bus_volume_db(AudioServer.get_bus_index(music.bus), linear_to_db(volume_between_0_and_1))
 
 
@@ -100,3 +102,11 @@ func stop_music(fade_out_duration: float = 0.0) -> void:
 
 func set_default_music_bus(bus: String) -> void:
 	music.bus = bus
+
+
+### Helpers
+
+
+func _show_shared_bus_warning() -> void:
+	if music.bus == sound_effects.bus or music.bus == ui_sound_effects.bus:
+		push_warning("Both music and sounds are using the same bus: %s" % music.bus)


### PR DESCRIPTION
This adds a warning when setting the music or sound volume if you are using the same bus for both:

![image](https://github.com/nathanhoad/godot_sound_manager/assets/78984/81f92fa6-8066-4bdd-bcc1-a087d3412c98)

Closes #7 