### PR TITLE
Add method for playing a sound with a given pitch

### DIFF
--- a/addons/sound_manager/sound_effects.gd
+++ b/addons/sound_manager/sound_effects.gd
@@ -1,8 +1,7 @@
 extends "res://addons/sound_manager/abstract_audio_player_pool.gd"
 
 
-func play(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
+func play(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
 	var player = prepare(resource, override_bus)
-	player.pitch_scale = pitch
 	player.call_deferred("play")
 	return player

--- a/addons/sound_manager/sound_effects.gd
+++ b/addons/sound_manager/sound_effects.gd
@@ -1,7 +1,7 @@
 extends "res://addons/sound_manager/abstract_audio_player_pool.gd"
 
 
-func play(resource: AudioStream, pitch : float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
+func play(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
 	var player = prepare(resource, override_bus)
 	player.pitch_scale = pitch
 	player.call_deferred("play")

--- a/addons/sound_manager/sound_effects.gd
+++ b/addons/sound_manager/sound_effects.gd
@@ -1,7 +1,8 @@
 extends "res://addons/sound_manager/abstract_audio_player_pool.gd"
 
 
-func play(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
+func play(resource: AudioStream, pitch : float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
 	var player = prepare(resource, override_bus)
+	player.pitch_scale = pitch
 	player.call_deferred("play")
 	return player

--- a/addons/sound_manager/sound_manager.gd
+++ b/addons/sound_manager/sound_manager.gd
@@ -52,19 +52,23 @@ func set_sound_volume(volume_between_0_and_1) -> void:
 
 
 func play_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
-	return sound_effects.play(resource, 1.0, override_bus)
+	return sound_effects.play(resource, override_bus)
 
 
 func play_sound_with_pitch(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
-	return sound_effects.play(resource, pitch, override_bus)
+	var player = sound_effects.play(resource, override_bus)
+	player.pitch_scale = pitch
+	return player
 
 
 func play_ui_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
-	return ui_sound_effects.play(resource, 1.0, override_bus)
+	return ui_sound_effects.play(resource, override_bus)
 
 
 func play_ui_sound_with_pitch(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
-	return ui_sound_effects.play(resource, pitch, override_bus)
+	var player = ui_sound_effects.play(resource, override_bus)
+	player.pitch_scale = pitch
+	return player
 
 
 func set_default_sound_bus(bus: String) -> void:

--- a/addons/sound_manager/sound_manager.gd
+++ b/addons/sound_manager/sound_manager.gd
@@ -51,11 +51,19 @@ func set_sound_volume(volume_between_0_and_1) -> void:
 	AudioServer.set_bus_volume_db(AudioServer.get_bus_index(ui_sound_effects.bus), linear_to_db(volume_between_0_and_1))
 
 
-func play_sound(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
+func play_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
+	return sound_effects.play(resource, 1.0, override_bus)
+
+
+func play_sound_with_pitch(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
 	return sound_effects.play(resource, pitch, override_bus)
 
 
-func play_ui_sound(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
+func play_ui_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
+	return ui_sound_effects.play(resource, 1.0, override_bus)
+
+
+func play_ui_sound_with_pitch(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
 	return ui_sound_effects.play(resource, pitch, override_bus)
 
 

--- a/addons/sound_manager/sound_manager.gd
+++ b/addons/sound_manager/sound_manager.gd
@@ -51,11 +51,11 @@ func set_sound_volume(volume_between_0_and_1) -> void:
 	AudioServer.set_bus_volume_db(AudioServer.get_bus_index(ui_sound_effects.bus), linear_to_db(volume_between_0_and_1))
 
 
-func play_sound(resource: AudioStream, pitch : float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
+func play_sound(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
 	return sound_effects.play(resource, pitch, override_bus)
 
 
-func play_ui_sound(resource: AudioStream, pitch : float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
+func play_ui_sound(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
 	return ui_sound_effects.play(resource, pitch, override_bus)
 
 

--- a/addons/sound_manager/sound_manager.gd
+++ b/addons/sound_manager/sound_manager.gd
@@ -51,12 +51,12 @@ func set_sound_volume(volume_between_0_and_1) -> void:
 	AudioServer.set_bus_volume_db(AudioServer.get_bus_index(ui_sound_effects.bus), linear_to_db(volume_between_0_and_1))
 
 
-func play_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
-	return sound_effects.play(resource, override_bus)
+func play_sound(resource: AudioStream, pitch : float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
+	return sound_effects.play(resource, pitch, override_bus)
 
 
-func play_ui_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
-	return ui_sound_effects.play(resource, override_bus)
+func play_ui_sound(resource: AudioStream, pitch : float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
+	return ui_sound_effects.play(resource, pitch, override_bus)
 
 
 func set_default_sound_bus(bus: String) -> void:

--- a/docs/Sounds.md
+++ b/docs/Sounds.md
@@ -20,11 +20,19 @@ Playing sound effects is broken up into playing general sounds (ie. in the game 
 
   This returns the `AudioStreamPlayer` that is playing the sound so you can adjust the pitch or volume.
 
+- **`SoundManager.play_sound_with_pitch(resource: AudioStream, pitch: float, override_bus: String = "") -> AudioStreamPlayer`**
+
+  Play an audio stream with a specific pitch. Optionally specify which audio bus you want to use for this sound.
+
 - **`SoundManager.play_ui_sound(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer`**
 
   Play an audio stream intended for the user interface. Optionally specify which audio bus you want to use for this sound.
 
   This returns the `AudioStreamPlayer` that is playing the sound so you can adjust the pitch or volume.
+
+- **`SoundManager.play_ui_sound_with_pitch(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer`**
+
+  Play a UI audio stream with a specific pitch. Optionally specify which audio bus you want to use for this sound.
 
 - **`SoundManager.set_default_sound_bus(bus: String) -> void`**
 

--- a/examples/example.gd
+++ b/examples/example.gd
@@ -55,4 +55,4 @@ func _on_music_volume_up_pressed() -> void:
 
 
 func _on_play_sound_random_pitch_pressed() -> void:
-	SoundManager.play_sound(sound_sample, randf_range(0.8, 1.2))
+	SoundManager.play_sound_with_pitch(sound_sample, randf_range(0.8, 1.2))

--- a/examples/example.gd
+++ b/examples/example.gd
@@ -52,3 +52,7 @@ func _on_music_volume_up_pressed() -> void:
 	var next_volume: float = clamp(SoundManager.get_music_volume() + 0.1, 0, 1)
 	SoundManager.set_music_volume(next_volume)
 	music_volume_label.text = "%d%%" % [round(next_volume * 100)]
+
+
+func _on_play_sound_random_pitch_pressed() -> void:
+	SoundManager.play_sound(sound_sample, randf_range(0.8, 1.2))

--- a/examples/example.tscn
+++ b/examples/example.tscn
@@ -22,18 +22,19 @@ offset_bottom = 40.0
 
 [node name="PlaySound" type="Button" parent="Sound"]
 layout_mode = 0
-offset_left = 290.0
-offset_top = 220.0
-offset_right = 429.0
-offset_bottom = 251.0
+offset_left = 176.0
+offset_top = 216.0
+offset_right = 315.0
+offset_bottom = 247.0
 text = "Play sound"
 
 [node name="PlaySoundAtRandomPitch" type="Button" parent="Sound"]
-offset_left = 248.0
-offset_top = 163.0
-offset_right = 473.0
-offset_bottom = 194.0
-text = "Play sound At Random Pitch"
+layout_mode = 0
+offset_left = 324.0
+offset_top = 216.0
+offset_right = 529.0
+offset_bottom = 247.0
+text = "Play with random pitch"
 
 [node name="VolumeDown" type="Button" parent="Sound"]
 layout_mode = 0
@@ -72,9 +73,10 @@ horizontal_alignment = 1
 [node name="Music" type="Control" parent="."]
 layout_mode = 3
 anchors_preset = 0
-offset_top = 99.0
-offset_right = 40.0
-offset_bottom = 139.0
+offset_left = 1.0
+offset_top = 142.0
+offset_right = 41.0
+offset_bottom = 182.0
 
 [node name="PlayMusic" type="Button" parent="Music"]
 layout_mode = 0

--- a/examples/example.tscn
+++ b/examples/example.tscn
@@ -28,6 +28,13 @@ offset_right = 429.0
 offset_bottom = 251.0
 text = "Play sound"
 
+[node name="PlaySoundAtRandomPitch" type="Button" parent="Sound"]
+offset_left = 248.0
+offset_top = 163.0
+offset_right = 473.0
+offset_bottom = 194.0
+text = "Play sound At Random Pitch"
+
 [node name="VolumeDown" type="Button" parent="Sound"]
 layout_mode = 0
 offset_left = 583.0
@@ -120,6 +127,7 @@ text = "50%"
 horizontal_alignment = 1
 
 [connection signal="pressed" from="Sound/PlaySound" to="." method="_on_play_sound_pressed"]
+[connection signal="pressed" from="Sound/PlaySoundAtRandomPitch" to="." method="_on_play_sound_random_pitch_pressed"]
 [connection signal="pressed" from="Sound/VolumeDown" to="." method="_on_volume_down_pressed"]
 [connection signal="pressed" from="Sound/VolumeUp" to="." method="_on_volume_up_pressed"]
 [connection signal="pressed" from="Music/PlayMusic" to="." method="_on_play_music_pressed"]


### PR DESCRIPTION
Changed `sound_effects.play()`, `SoundManager.play_sound()`, and `SoundManager.play_ui_sound()` functions to accept a pitch parameter.

Added an example of a random pitch sound effect to `Example.tscn`.