### PR TITLE
Fix fade behaviour when tree is paused

### DIFF
--- a/addons/sound_manager/music.gd
+++ b/addons/sound_manager/music.gd
@@ -88,7 +88,7 @@ func fade_volume(player: AudioStreamPlayer, from_volume: float, to_volume: float
 	_remove_tween(player)
 
 	# Start a new tween
-	var tween: Tween = get_tree().create_tween()
+	var tween: Tween = get_tree().create_tween().bind_node(self)
 
 	player.volume_db = from_volume
 	if from_volume > to_volume:


### PR DESCRIPTION
Currently if you attempt to play music with a cross-fade while `get_tree().paused` is true, the music will not switch. This change adds a `bind_node` call to bind the tween to the player node and not the `SceneTree` so that cross-fade tweens will work in the player's process mode.