### PR TITLE
Fix issue with automatic bus detection

### DIFF
--- a/addons/sound_manager/abstract_audio_player_pool.gd
+++ b/addons/sound_manager/abstract_audio_player_pool.gd
@@ -11,6 +11,12 @@ var bus: String = "Master"
 
 
 func _init(possible_busses: PackedStringArray = default_busses, pool_size: int = default_pool_size) -> void:
+	bus = get_possible_bus(possible_busses)
+
+	for i in pool_size:
+		increase_pool()
+
+func get_possible_bus(possible_busses: PackedStringArray) -> String: 
 	for possible_bus in possible_busses:
 		var cases: PackedStringArray = [
 			possible_bus,
@@ -21,12 +27,8 @@ func _init(possible_busses: PackedStringArray = default_busses, pool_size: int =
 		]
 		for case in cases:
 			if AudioServer.get_bus_index(case) > -1:
-				bus = case
-				break
-
-	for i in pool_size:
-		increase_pool()
-
+				return case
+	return "Master"
 
 func prepare(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
 	var player: AudioStreamPlayer


### PR DESCRIPTION
Hello!

I noticed a small bug in the bus matching logic.
When we get a matching bus, we break out of the cases loop but it is nested under another one, so we continue iterating, even if there is a match.