### PR TITLE
Documentation - Fix Typo `desribed` in Last Sentence of Music.md

### DIFF
--- a/docs/Music.md
+++ b/docs/Music.md
@@ -76,4 +76,4 @@
 
 By default, music is not paused when the game is paused. To change this you can set `SoundManager.music_process_mode`. The value is of type `ProcessMode`.
 
-You can also make use of the `pause_music` method desribed above.
+You can also make use of the `pause_music` method described above.


### PR DESCRIPTION
Fix the only typo of the documentation folder `docs/` for readability.