### PR TITLE
Fixed incorrect function being called in get_currently_playing_musi_tracks()

### DIFF
--- a/addons/sound_manager/sound_manager.gd
+++ b/addons/sound_manager/sound_manager.gd
@@ -184,7 +184,7 @@ func get_currently_playing_music() -> Array:
 
 
 func get_currently_playing_music_tracks() -> Array:
-	return music.get_current_tracks()
+	return music.get_currently_playing_tracks()
 
 
 func pause_music(resource: AudioStream = null) -> void:


### PR DESCRIPTION
Fixed incorrect function being called in get_currently_playing_musi_tracks().

`music.get_current_tracks()` doesn't exist should be `music.get_currently_playing_tracks()`