### PR TITLE
Fix all warnings related to unused values and missing types

### DIFF
--- a/addons/sound_manager/abstract_audio_player_pool.gd
+++ b/addons/sound_manager/abstract_audio_player_pool.gd
@@ -9,7 +9,7 @@ var available_players: Array[AudioStreamPlayer] = []
 var busy_players: Array[AudioStreamPlayer] = []
 var bus: String = "Master"
 
-var _tweens: Dictionary = {}
+var _tweens: Dictionary[AudioStreamPlayer, Tween] = {}
 
 
 func _init(possible_busses: PackedStringArray = default_busses, pool_size: int = default_pool_size) -> void:
@@ -52,7 +52,7 @@ func prepare(resource: AudioStream, override_bus: String = "") -> AudioStreamPla
 func get_available_player() -> AudioStreamPlayer:
 	if available_players.size() == 0:
 		increase_pool()
-	var player = available_players.pop_front()
+	var player : Variant = available_players.pop_front()
 	busy_players.append(player)
 	return player
 
@@ -76,7 +76,6 @@ func mark_player_as_available(player: AudioStreamPlayer) -> void:
 		busy_players.erase(player)
 
 	if available_players.size() >= default_pool_size:
-		available_players.erase(player)
 		player.queue_free()
 	elif not available_players.has(player):
 		available_players.append(player)
@@ -94,6 +93,7 @@ func increase_pool() -> void:
 	add_child(player)
 	available_players.append(player)
 	player.bus = bus
+	@warning_ignore("return_value_discarded")
 	player.finished.connect(_on_player_finished.bind(player))
 
 
@@ -107,12 +107,15 @@ func fade_volume(player: AudioStreamPlayer, from_volume: float, to_volume: float
 	player.volume_db = from_volume
 	if from_volume > to_volume:
 		# Fade out
+		@warning_ignore("return_value_discarded")
 		tween.tween_property(player, "volume_db", to_volume, duration).set_trans(Tween.TRANS_CIRC).set_ease(Tween.EASE_IN)
 	else:
 		# Fade in
+		@warning_ignore("return_value_discarded")
 		tween.tween_property(player, "volume_db", to_volume, duration).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_OUT)
 
 	_tweens[player] = tween
+	@warning_ignore("return_value_discarded")
 	tween.finished.connect(_on_fade_completed.bind(player, tween, from_volume, to_volume, duration))
 
 	return player
@@ -125,6 +128,7 @@ func _remove_tween(player: AudioStreamPlayer) -> void:
 	if _tweens.has(player):
 		var fade: Tween = _tweens.get(player)
 		fade.kill()
+		@warning_ignore("return_value_discarded")
 		_tweens.erase(player)
 
 
@@ -137,7 +141,7 @@ func _on_player_finished(player: AudioStreamPlayer) -> void:
 	mark_player_as_available(player)
 
 
-func _on_fade_completed(player: AudioStreamPlayer, tween: Tween, from_volume: float, to_volume: float, duration: float):
+func _on_fade_completed(player: AudioStreamPlayer, _tween: Tween, _from_volume: float, to_volume: float, _duration: float) -> void:
 	_remove_tween(player)
 
 	# If we just faded out then our player is now available

--- a/addons/sound_manager/ambient_sounds.gd
+++ b/addons/sound_manager/ambient_sounds.gd
@@ -2,12 +2,13 @@ extends "./abstract_audio_player_pool.gd"
 
 
 func play(resource: AudioStream, fade_in_duration: float, override_bus: String = "") -> AudioStreamPlayer:
-	var player = get_busy_player_with_resource(resource)
+	var player := get_busy_player_with_resource(resource)
 
 	# If it's already playing then don't play it again
 	if is_instance_valid(player): return player
 
 	player = prepare(resource, override_bus)
+	@warning_ignore("return_value_discarded")
 	fade_volume(player, -80.0, 0.0, fade_in_duration)
 	player.call_deferred("play")
 	return player
@@ -19,6 +20,7 @@ func stop(resource: AudioStream, fade_out_duration: float = 0.0) -> void:
 
 	for player in busy_players:
 		if player.stream == resource:
+			@warning_ignore("return_value_discarded")
 			fade_volume(player, player.volume_db, -80, fade_out_duration)
 
 
@@ -27,4 +29,5 @@ func stop_all(fade_out_duration: float = 0.0) -> void:
 			fade_out_duration = 0.01
 
 	for player in busy_players:
+		@warning_ignore("return_value_discarded")
 		fade_volume(player, player.volume_db, -80, fade_out_duration)

--- a/addons/sound_manager/music.gd
+++ b/addons/sound_manager/music.gd
@@ -7,18 +7,21 @@ var track_history: PackedStringArray = []
 func play(resource: AudioStream, position: float = 0.0, volume: float = 0.0, crossfade_duration: float = 0.0, override_bus: String = "") -> AudioStreamPlayer:
 	stop(crossfade_duration * 2)
 
-	var player = get_busy_player_with_resource(resource)
+	var player := get_busy_player_with_resource(resource)
 
 	# If the player already exists then just make sure the volume is right (it might have just been fading in or out)
 	if player != null:
+		@warning_ignore("return_value_discarded")
 		fade_volume(player, player.volume_db, volume, crossfade_duration)
 		return player
 
 	# Otherwise we need to prep another player and handle its introduction
 	player = prepare(resource, override_bus)
+	@warning_ignore("return_value_discarded")
 	fade_volume(player, -80.0, volume, crossfade_duration)
 
 	# Remember this track name
+	@warning_ignore("return_value_discarded")
 	track_history.insert(0, resource.resource_path)
 	if track_history.size() > 50:
 		track_history.remove_at(50)
@@ -38,12 +41,13 @@ func stop(fade_out_duration: float = 0.0) -> void:
 	for player in busy_players:
 		if fade_out_duration <= 0.0:
 			fade_out_duration = 0.01
+		@warning_ignore("return_value_discarded")
 		fade_volume(player, player.volume_db, -80, fade_out_duration)
 
 
 func pause(resource: AudioStream = null) -> void:
 	if resource != null:
-		var player = get_busy_player_with_resource(resource)
+		var player := get_busy_player_with_resource(resource)
 		if is_instance_valid(player):
 			player.stream_paused = true
 	else:
@@ -53,7 +57,7 @@ func pause(resource: AudioStream = null) -> void:
 
 func resume(resource: AudioStream = null) -> void:
 	if resource != null:
-		var player = get_busy_player_with_resource(resource)
+		var player := get_busy_player_with_resource(resource)
 		if is_instance_valid(player):
 			player.stream_paused = false
 	else:
@@ -78,5 +82,6 @@ func get_currently_playing() -> Array[AudioStream]:
 func get_currently_playing_tracks() -> PackedStringArray:
 	var tracks: PackedStringArray = []
 	for player in busy_players:
+		@warning_ignore("return_value_discarded")
 		tracks.append(player.stream.resource_path)
 	return tracks

--- a/addons/sound_manager/sound_effects.gd
+++ b/addons/sound_manager/sound_effects.gd
@@ -2,7 +2,7 @@ extends "./abstract_audio_player_pool.gd"
 
 
 func play(resource: AudioStream, override_bus: String = "") -> AudioStreamPlayer:
-	var player = prepare(resource, override_bus)
+	var player := prepare(resource, override_bus)
 	player.call_deferred("play")
 	return player
 

--- a/addons/sound_manager/sound_manager.gd
+++ b/addons/sound_manager/sound_manager.gd
@@ -68,7 +68,7 @@ func play_sound(resource: AudioStream, override_bus: String = "") -> AudioStream
 
 
 func play_sound_with_pitch(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
-	var player = sound_effects.play(resource, override_bus)
+	var player := sound_effects.play(resource, override_bus)
 	player.pitch_scale = pitch
 	return player
 
@@ -100,7 +100,7 @@ func play_ui_sound(resource: AudioStream, override_bus: String = "") -> AudioStr
 
 
 func play_ui_sound_with_pitch(resource: AudioStream, pitch: float = 1.0, override_bus: String = "") -> AudioStreamPlayer:
-	var player = ui_sound_effects.play(resource, override_bus)
+	var player := ui_sound_effects.play(resource, override_bus)
 	player.pitch_scale = pitch
 	return player
 


### PR DESCRIPTION
This pull request fixes the following warnings:
- Static typing
- Unused value

This *does* introduce a potentially breaking change for anyone not running Godot 4.4+. To fix all static typing going forward, a typed Dictionary was used. Typed Dictionary was something introduced in Godot 4.4 so this could break things for people. It's up to you if you'd like to remove it to maintain support for versions before 4.4. Or just rip the band-aid off and push forward! 😄  Either way, it works even if you just remove the type from it.